### PR TITLE
Add Maintainer Endpoint

### DIFF
--- a/app/controllers/teams.js
+++ b/app/controllers/teams.js
@@ -7,5 +7,9 @@ const addMembersToTeam = (req, res) =>
   Promise.all(req.body.usernames.map(user => github.addMemberToTeam(req.params.teamId, user))).then(resp =>
     res.send(resp)
   );
+const addMaintainersToTeam = (req, res) =>
+  Promise.all(req.body.usernames.map(user => github.addMaintainerToTeam(req.params.teamId, user))).then(
+    resp => res.send(resp)
+  );
 
-module.exports = { getTeams, createTeam, addMembersToTeam, deleteTeam };
+module.exports = { getTeams, createTeam, addMembersToTeam, addMaintainersToTeam, deleteTeam };

--- a/app/interactors/github.js
+++ b/app/interactors/github.js
@@ -2,6 +2,7 @@ const {
   createRepository: create,
   addDefaultTeamsToRepository,
   addTeamToRepository,
+  addMaintainerToTeam: addMaintainerToTeamGithub,
   addMemberToTeam: addMemberToTeamGithub,
   addCodeownersToRepo: addCodeownersToRepoGithub,
   deleteTeam: deleteTeamGithub,
@@ -41,6 +42,9 @@ const addTeamToRepo = (teamId, repositoryName) =>
 const addMemberToTeam = (teamId, username) =>
   addMemberToTeamGithub({ teamId, username }).then(resp => resp.data);
 
+const addMaintainerToTeam = (teamId, username) =>
+  addMaintainerToTeamGithub({ teamId, username }).then(resp => resp.data);
+
 const addCodeownersToRepo = (repositoryName, codeowners) =>
   addCodeownersToRepoGithub({ repositoryName, codeowners }).then(resp => resp.data);
 
@@ -54,6 +58,7 @@ module.exports = {
   createTeam,
   addTeamToRepo,
   addMemberToTeam,
+  addMaintainerToTeam,
   addCodeownersToRepo,
   deleteTeam,
   addUser

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,13 @@ const {
   addCodeownersToRepo,
   addUserToOrganization
 } = require('./controllers/github');
-const { getTeams, createTeam, addMembersToTeam, deleteTeam } = require('./controllers/teams');
+const {
+  getTeams,
+  createTeam,
+  addMembersToTeam,
+  addMaintainersToTeam,
+  deleteTeam
+} = require('./controllers/teams');
 const { healthCheck } = require('./controllers/healthCheck');
 const { getUsersHandler, setUserMaintainerHandler, setUserAdminHandler } = require('./controllers/users.js');
 const checkJwt = require('./middlewares/checkAuth');
@@ -27,6 +33,7 @@ exports.init = app => {
   app.get('/teams', checkJwt, checkPerms(['manage:teams']), getTeams);
   app.post('/teams', checkJwt, checkPerms(['manage:teams']), createTeam);
   app.post('/teams/:teamId/members', checkJwt, checkPerms(['manage:teams']), addMembersToTeam);
+  app.post('/teams/:teamId/maintainers', checkJwt, checkPerms(['manage:teams']), addMaintainersToTeam);
   app.delete('/teams/:teamId', checkJwt, checkPerms(['manage:teams']), deleteTeam);
 
   app.get('/users', checkJwt, checkPerms(['add:role']), getUsersHandler);

--- a/app/services/github/repositories.js
+++ b/app/services/github/repositories.js
@@ -71,6 +71,13 @@ const addMemberToTeam = ({ teamId, username }) =>
     username
   });
 
+const addMaintainerToTeam = ({ teamId, username }) =>
+  org.teams.addOrUpdateMembership({
+    team_id: teamId,
+    role: 'maintainer',
+    username
+  });
+
 const deleteTeam = ({ teamId }) =>
   org.teams.delete({
     team_id: teamId
@@ -98,6 +105,7 @@ module.exports = {
   addDefaultTeamsToRepository,
   addTeamToRepository,
   addMemberToTeam,
+  addMaintainerToTeam,
   addCodeownersToRepo,
   deleteTeam
 };


### PR DESCRIPTION
## Summary

New endpoint to add a maintainer user to a Team. The user can already be part of the team.

POST /teams/:teamId/maintainers

**Auth**: requires `manage:teams`

**Body**:
```json
{ 
	"usernames": ["githubUser"]
}
```